### PR TITLE
Show unwrapped txs in explore

### DIFF
--- a/chains/testnet/kiichain.json
+++ b/chains/testnet/kiichain.json
@@ -1,9 +1,12 @@
 {
   "chain_name": "kiichain",
-  "api": ["https://a.sentry.testnet.kiivalidator.com", "https://b.sentry.testnet.kiivalidator.com"],
+  "api": [
+    "https://a.sentry.testnet.kiivalidator.com",
+    "https://b.sentry.testnet.kiivalidator.com"
+  ],
   "rpc": [
-    "https://a.sentry.testnet.kiivalidator.com:26658",
-    "https://b.sentry.testnet.kiivalidator.com:26658"
+    "https://a.sentry.testnet.kiivalidator.com:8645",
+    "https://b.sentry.testnet.kiivalidator.com:8645"
   ],
   "snapshot_provider": "",
   "sdk_version": "0.45.11",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "cross-fetch": "^3.1.5",
     "daisyui": "^3.1.0",
     "dayjs": "^1.11.7",
+    "ethers": "^6.13.0",
     "lazy-load-vue3": "^1.3.0",
     "long": "^5.2.1",
     "md-editor-v3": "^2.8.1",

--- a/src/libs/client.ts
+++ b/src/libs/client.ts
@@ -11,7 +11,9 @@ import {
   registryVersionProfile,
   withCustomRequest,
 } from './registry';
-import { PageRequest,type Coin } from '@/types';
+import { PageRequest, type Coin } from '@/types';
+import { getTransactionsEVM } from './ethers';
+import { useRoute } from 'vue-router';
 
 export class BaseRestClient<R extends AbstractRegistry> {
   endpoint: string;
@@ -31,41 +33,42 @@ export class BaseRestClient<R extends AbstractRegistry> {
 
 // dynamic all custom request implementations
 function registeCustomRequest() {
-  const extensions: Record<string, any> = import.meta.glob('./clients/*.ts', { eager: true });
-  Object.values(extensions).forEach(m => {
-    if(m.store === 'version') {
-      registryVersionProfile(m.name, withCustomRequest(DEFAULT, m.requests))
+  const extensions: Record<string, any> = import.meta.glob('./clients/*.ts', {
+    eager: true,
+  });
+  Object.values(extensions).forEach((m) => {
+    if (m.store === 'version') {
+      registryVersionProfile(m.name, withCustomRequest(DEFAULT, m.requests));
     } else {
       registryChainProfile(m.name, withCustomRequest(DEFAULT, m.requests));
     }
   });
 }
-    
-registeCustomRequest()
+
+registeCustomRequest();
 
 export class CosmosRestClient extends BaseRestClient<RequestRegistry> {
   static newDefault(endpoint: string) {
-    return new CosmosRestClient(endpoint, DEFAULT)
+    return new CosmosRestClient(endpoint, DEFAULT);
   }
 
   static newStrategy(endpoint: string, chain: any) {
-    
-    let req
-    if(chain) {
+    let req;
+    if (chain) {
       // find by name first
-      req = findApiProfileByChain(chain.chainName)
+      req = findApiProfileByChain(chain.chainName);
       // if not found. try sdk version
-      if(!req && chain.versions?.cosmosSdk) {
-        req = findApiProfileBySDKVersion(chain.versions?.cosmosSdk)
+      if (!req && chain.versions?.cosmosSdk) {
+        req = findApiProfileBySDKVersion(chain.versions?.cosmosSdk);
       }
     }
-    return new CosmosRestClient(endpoint, req || DEFAULT)
+    return new CosmosRestClient(endpoint, req || DEFAULT);
   }
 
   // Auth Module
   async getAuthAccounts(page?: PageRequest) {
-    if(!page) page = new PageRequest()
-    const query =`?${page.toQueryString()}`;
+    if (!page) page = new PageRequest();
+    const query = `?${page.toQueryString()}`;
     return this.request(this.registry.auth_accounts, {}, query);
   }
   async getAuthAccount(address: string) {
@@ -84,22 +87,30 @@ export class CosmosRestClient extends BaseRestClient<RequestRegistry> {
   async getBankDenomOwners(denom: string, page?: PageRequest) {
     if (!page) page = new PageRequest();
     const query = `?${page.toQueryString()}`;
-    return this.request(this.registry.bank_denom_owners, { denom },query);
+    return this.request(this.registry.bank_denom_owners, { denom }, query);
   }
-  async getBankSupply(page?: PageRequest) {    
-    if(!page) page = new PageRequest()
-    const query =`?${page.toQueryString()}`;
+  async getBankSupply(page?: PageRequest) {
+    if (!page) page = new PageRequest();
+    const query = `?${page.toQueryString()}`;
     return this.request(this.registry.bank_supply, {}, query);
   }
   async getBankSupplyByDenom(denom: string) {
     let supply;
-    try{
-       supply = await this.request(this.registry.bank_supply_by_denom, { denom });
-    } catch(err) {
+    try {
+      supply = await this.request(this.registry.bank_supply_by_denom, {
+        denom,
+      });
+    } catch (err) {
       // will move this to sdk version profile later
-      supply = await this.request({url: "/cosmos/bank/v1beta1/supply/by_denom?denom={denom}", adapter } as Request<{ amount: Coin }>, { denom });
+      supply = await this.request(
+        {
+          url: '/cosmos/bank/v1beta1/supply/by_denom?denom={denom}',
+          adapter,
+        } as Request<{ amount: Coin }>,
+        { denom }
+      );
     }
-    return supply
+    return supply;
   }
   // Distribution Module
   async getDistributionParams() {
@@ -148,9 +159,9 @@ export class CosmosRestClient extends BaseRestClient<RequestRegistry> {
     return this.request(this.registry.gov_params_tally, {});
   }
   async getGovProposals(status: string, page?: PageRequest) {
-    if(!page) page = new PageRequest()
-    page.reverse = true
-    const query =`?proposal_status={status}&${page.toQueryString()}`;
+    if (!page) page = new PageRequest();
+    page.reverse = true;
+    const query = `?proposal_status={status}&${page.toQueryString()}`;
     return this.request(this.registry.gov_proposals, { status }, query);
   }
   async getGovProposal(proposal_id: string) {
@@ -165,10 +176,14 @@ export class CosmosRestClient extends BaseRestClient<RequestRegistry> {
     return this.request(this.registry.gov_proposals_tally, { proposal_id });
   }
   async getGovProposalVotes(proposal_id: string, page?: PageRequest) {
-    if(!page) page = new PageRequest()
-    page.reverse = true
-    const query =`?proposal_status={status}&${page.toQueryString()}`;
-    return this.request(this.registry.gov_proposals_votes, { proposal_id }, query);
+    if (!page) page = new PageRequest();
+    page.reverse = true;
+    const query = `?proposal_status={status}&${page.toQueryString()}`;
+    return this.request(
+      this.registry.gov_proposals_votes,
+      { proposal_id },
+      query
+    );
   }
   async getGovProposalVotesVoter(proposal_id: string, voter: string) {
     return this.request(this.registry.gov_proposals_votes_voter, {
@@ -247,25 +262,37 @@ export class CosmosRestClient extends BaseRestClient<RequestRegistry> {
     return this.request(this.registry.base_tendermint_node_info, {});
   }
   async getBaseValidatorsetAt(height: string | number, offset: number) {
-    const query = `?pagination.limit=100&pagination.offset=${offset}`
-    return this.request(this.registry.base_tendermint_validatorsets_height, {
-      height,
-    }, query);
+    const query = `?pagination.limit=100&pagination.offset=${offset}`;
+    return this.request(
+      this.registry.base_tendermint_validatorsets_height,
+      {
+        height,
+      },
+      query
+    );
   }
   async getBaseValidatorsetLatest(offset: number) {
-    const query = `?pagination.limit=100&pagination.offset=${offset}`
-    return this.request(this.registry.base_tendermint_validatorsets_latest, {}, query);
+    const query = `?pagination.limit=100&pagination.offset=${offset}`;
+    return this.request(
+      this.registry.base_tendermint_validatorsets_latest,
+      {},
+      query
+    );
   }
   // tx
   async getTxsBySender(sender: string, page?: PageRequest) {
-    if(!page) page = new PageRequest()
-    const query = `?&events=message.sender='${sender}'&order_by=2&pagination.limit=${page.limit}&pagination.offset=${page.offset||0}`;
+    if (!page) page = new PageRequest();
+    const query = `?&events=message.sender='${sender}'&order_by=2&pagination.limit=${
+      page.limit
+    }&pagination.offset=${page.offset || 0}`;
     return this.request(this.registry.tx_txs, {}, query);
   }
   // tx received
   async getTxsReceived(address: string, page?: PageRequest) {
-    if(!page) page = new PageRequest()
-    const query = `?&events=transfer.recipient='${address}'&order_by=2&pagination.limit=${page.limit}&pagination.offset=${page.offset||0}`;
+    if (!page) page = new PageRequest();
+    const query = `?&events=transfer.recipient='${address}'&order_by=2&pagination.limit=${
+      page.limit
+    }&pagination.offset=${page.offset || 0}`;
     return this.request(this.registry.tx_txs, {}, query);
   }
   // query ibc sending msgs
@@ -273,8 +300,12 @@ export class CosmosRestClient extends BaseRestClient<RequestRegistry> {
   // query ibc receiving msgs
   // ?&pagination.reverse=true&events=recv_packet.packet_dst_channel='${channel}'&events=recv_packet.packet_dst_port='${port}'
   async getTxs(query: string, params: any, page?: PageRequest) {
-    if(!page) page = new PageRequest()    
-    return this.request(this.registry.tx_txs, params, `${query}&${page.toQueryString()}`);
+    if (!page) page = new PageRequest();
+    return this.request(
+      this.registry.tx_txs,
+      params,
+      `${query}&${page.toQueryString()}`
+    );
   }
   async getTxsCount() {
     const query = `?&events=message.action='/cosmos.bank.v1beta1.MsgSend'&pagination.count_total=true`;
@@ -289,12 +320,7 @@ export class CosmosRestClient extends BaseRestClient<RequestRegistry> {
     return this.request(this.registry.tx_txs, {}, `${query}`);
   }
   async getLatestTxsEvm(page?: PageRequest) {
-    if(!page){
-      page = new PageRequest()
-      page.limit = 20;
-    }
-    const query = `?query=transfer.msg_index='0'&order_by=2&pagination.limit=${page.limit}&pagination.offset=${page.offset||0}`;
-    return this.request(this.registry.tx_txs, {}, `${query}&${page.toQueryString()}`);
+    return await getTransactionsEVM();
   }
   async getTxsAt(height: string | number) {
     return this.request(this.registry.tx_txs_block, { height });
@@ -321,9 +347,13 @@ export class CosmosRestClient extends BaseRestClient<RequestRegistry> {
     });
   }
   async getIBCConnections(page?: PageRequest) {
-    if(!page) page = new PageRequest()
-    const query =`?${page.toQueryString()}`;
-    return this.request(this.registry.ibc_core_connection_connections, {}, query);
+    if (!page) page = new PageRequest();
+    const query = `?${page.toQueryString()}`;
+    return this.request(
+      this.registry.ibc_core_connection_connections,
+      {},
+      query
+    );
   }
   async getIBCConnectionsById(connection_id: string) {
     return this.request(

--- a/src/libs/ethers.ts
+++ b/src/libs/ethers.ts
@@ -1,0 +1,138 @@
+import { type Coin, type TxResponse } from '@/types';
+import kiichain from '../../chains/testnet/kiichain.json';
+import { ethers, TransactionResponse } from 'ethers';
+
+const getTransactionEVM = async (
+  transactionHash: string,
+  provider: ethers.JsonRpcProvider
+): Promise<TransactionResponse | null> => {
+  try {
+    return await provider.getTransaction(transactionHash);
+  } catch (error) {
+    console.error('Error getting the transaction from hash:', error);
+    return null;
+  }
+};
+
+export const getTransactionsEVM = async (): Promise<
+  TxResponse[] | undefined
+> => {
+  try {
+    const provider = new ethers.JsonRpcProvider(kiichain.rpc[0]);
+    if (!provider) throw new Error('Missing provider');
+    const blockNumber = await provider.getBlockNumber();
+    const userTransactions: TxResponse[] = [];
+    const blocksPerPage = 40000;
+    const startBlock = blockNumber - blocksPerPage;
+
+    const rawblocks = await Promise.all(
+      Array.from(
+        { length: blocksPerPage },
+        (_, index) => startBlock! - index
+      ).map(async (blockNumber) => provider.getBlock(blockNumber, true))
+    );
+
+    const blocks = rawblocks.filter((block) => block && block.transactions);
+    const transactionPromises = blocks.flatMap((block) => {
+      if (!block || !block.transactions) return [];
+      return block.transactions.map(async (hash) => {
+        const transaction = await getTransactionEVM(hash, provider);
+        if (transaction) {
+          return convertTransaction(transaction, block);
+        }
+      });
+    });
+
+    const transactions = await Promise.all(transactionPromises);
+    const validTransactions = transactions.filter(
+      (tx): tx is TxResponse => tx !== null
+    );
+    userTransactions.push(...validTransactions!);
+    return userTransactions;
+  } catch (error) {
+    console.error('Error fetching the transaction history:', error);
+  }
+};
+
+const convertTransaction = (
+  transaction: TransactionResponse,
+  block: ethers.Block
+): TxResponse => {
+  const { value, blockNumber, type, data, gasLimit, hash, from, to } =
+    transaction;
+  const { assets } = kiichain;
+  const assetSymbol = assets[0].symbol;
+
+  const amount: Coin = {
+    amount: ethers.formatEther(value),
+    denom: assetSymbol,
+  };
+
+  const fee: Coin[] = [
+    {
+      amount: '',
+      denom: assetSymbol,
+    },
+  ];
+
+  return {
+    height: blockNumber!.toString(),
+    code: type,
+    data: data,
+    codespace: '',
+    events: [],
+    gas_used: gasLimit.toString(),
+    gas_wanted: '',
+    logs: [
+      {
+        msg_index: 0,
+        log: '',
+        events: [],
+      },
+    ],
+    timestamp: new Date(block.timestamp * 1000).toISOString(),
+    txhash: hash,
+    info: '',
+    raw_log: '',
+    tx: {
+      signatures: [],
+      auth_info: {
+        fee: {
+          gas_limit: gasLimit.toString(),
+          granter: '',
+          payer: '',
+          amount: fee,
+        },
+        signer_infos: [
+          {
+            public_key: {
+              '@type': '',
+              key: '',
+            },
+            mode_info: {
+              single: {
+                mode: '',
+              },
+            },
+            sequence: '',
+          },
+        ],
+      },
+      body: {
+        extension_options: [],
+        memo: '',
+        messages: [
+          {
+            from_address: from,
+            to_address: to!,
+            amount: amount,
+            '@type': '',
+          },
+        ],
+        non_critical_extension_options: [],
+        timeout_height: '',
+      },
+      '@type': 'TransactionResponse',
+    },
+  };
+};

--- a/src/modules/[chain]/index.vue
+++ b/src/modules/[chain]/index.vue
@@ -16,7 +16,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { Icon } from '@iconify/vue';
 import { computed, onMounted, ref } from 'vue';
 import router from '@/router';
-import type { Tx, TxResponse } from '@/types';
+import type { Coin, Tx, TxResponse } from '@/types';
 import { shortenAddress } from '@/libs/utils';
 import { defineChain, createPublicClient, http, decodeFunctionData, parseUnits } from 'viem'
 import bankAbi from '@/assets/abi/bank.json'
@@ -53,8 +53,9 @@ onMounted(async () => {
     if(isKiichain){
       const gasPrice = await publicClient.getGasPrice() 
       gasPriceEvm.value = gasPrice.toString()
-      latestTransactions.value = await bankStore.fetchLatestTxsEvm(blockStore.current?.assets[0].base ?? '');
-      transactionsCount.value = await blockStore.rpc.getTxsCountEvm();
+      const transactions = await bankStore.fetchLatestTxsEvm(blockStore.current?.assets[0].base ?? '');
+      latestTransactions.value = transactions.slice(0, 20);
+      transactionsCount.value = transactions.length
       return
     }
     const txCount = await blockStore.rpc.getTxsCount();
@@ -71,6 +72,17 @@ const latestBlocks = computed(() => {
   return baseStore.recents.reverse().slice(0, 20);
 });
 
+const getAmountEVM = (transaction : TxResponse): Coin=>{
+  const data = transaction.tx.body.messages[0].amount;
+  const amount = Array.isArray(data)?data[0].amount:data.amount || '0'
+    const denom = Array.isArray(data)?data[0].denom:data.denom || 'tkii'
+
+  return {
+    amount,
+    denom
+  }
+
+}
 
 // TODO: does not work.  Verify currentTx outputs an object
 // function computeTx(items: Tx[]) {
@@ -344,7 +356,7 @@ function confirm() {
               <span class="text-black dark:text-white">From: </span>
               <span class="text-info font-semibold">{{
                 shortenAddress(
-                  isKiichain?(item.events.find(ev => ev.type === 'transfer')?.attributes.find(att => att.key === 'sender')?.value || ''):(item.tx.body.messages[0]['from_address'] || ''),
+                  item.tx.body.messages[0]['from_address'] || '',
                   20,
                   0
                 )
@@ -354,7 +366,7 @@ function confirm() {
               <span class="text-black dark:text-white">To: </span>
               <span class="text-info font-semibold">{{
                 shortenAddress(
-                  isKiichain?(item.events.find(ev => ev.type === 'transfer')?.attributes.find(att => att.key === 'recipient')?.value || ''):(item.tx.body.messages[0]['to_address'] || ''),
+                  item.tx.body.messages[0]['to_address'] || '',
                   20,
                   0
                 )
@@ -363,14 +375,7 @@ function confirm() {
           </td>
           <td class="py-4 text-info font-semibold">
             {{
-                !isKiichain ? format.formatToken(
-                  Array.isArray(item.tx.body.messages[0]['amount'])
-                    ? item.tx.body.messages[0]['amount'][0]
-                    : item.tx.body.messages[0]['amount']
-                ):format.formatToken({ 
-                  denom: item.events.find(ev => ev.type === 'transfer')?.attributes.find(att => att.key === 'amount')?.value.replace(/[^A-Za-z]/g, "") || 'tkii' ,
-                  amount: item.events.find(ev => ev.type === 'transfer')?.attributes.find(att => att.key === 'amount')?.value.replace(/\D/g,'') || '0' 
-                })
+                format.formatToken(getAmountEVM(item))
             }}
           </td>
         </tr>

--- a/src/stores/useBankStore.ts
+++ b/src/stores/useBankStore.ts
@@ -18,7 +18,7 @@ export const useBankStore = defineStore('bankstore', {
       supply: {} as Coin,
       balances: {} as Record<string, Coin[]>,
       totalSupply: { supply: [] as Coin[] },
-      ibcDenoms: {} as Record<string, DenomTrace>
+      ibcDenoms: {} as Record<string, DenomTrace>,
     };
   },
   getters: {
@@ -52,7 +52,7 @@ export const useBankStore = defineStore('bankstore', {
 
       while (fetch) {
         const pageRequest = new PageRequest();
-        pageRequest.key = encodeURIComponent(key ?? '') ;
+        pageRequest.key = encodeURIComponent(key ?? '');
 
         const data = await this.blockchain.rpc.getBankDenomOwners(
           denom,
@@ -77,7 +77,7 @@ export const useBankStore = defineStore('bankstore', {
 
       while (fetch) {
         const pageRequest = new PageRequest();
-        pageRequest.key = encodeURIComponent(key ?? '') ;
+        pageRequest.key = encodeURIComponent(key ?? '');
 
         const data = await this.blockchain.rpc.getBankDenomOwners(
           denom,
@@ -122,9 +122,7 @@ export const useBankStore = defineStore('bankstore', {
       const totalPage = Math.ceil(totalCount / 100);
 
       while (fetch && currentPage <= totalPage && currentPage < 3) {
-        const data = await this.blockchain.rpc.getLatestTxs(
-          currentPage
-        );
+        const data = await this.blockchain.rpc.getLatestTxs(currentPage);
 
         if (data.tx_responses.length) {
           allData = [...allData, ...data.tx_responses];
@@ -132,12 +130,14 @@ export const useBankStore = defineStore('bankstore', {
           fetch = false;
         }
 
-        const givenDate = dayjs(data.tx_responses[data.tx_responses.length - 1].timestamp);
+        const givenDate = dayjs(
+          data.tx_responses[data.tx_responses.length - 1].timestamp
+        );
 
         if (givenDate.isBefore(oneMonthAgoDate)) {
           break;
         }
-        
+
         currentPage = currentPage + 1;
       }
 
@@ -145,8 +145,8 @@ export const useBankStore = defineStore('bankstore', {
     },
     async fetchLatestTxsEvm(denom: string): Promise<TxResponse[]> {
       const data = await this.blockchain.rpc.getLatestTxsEvm();
-  
-      return data.tx_responses;
+
+      return data!;
     },
   },
 });

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -1,77 +1,77 @@
-import type { Coin, Key, PaginatedResponse } from "./common"
+import type { Coin, Key, PaginatedResponse } from './common';
 
-export interface Message{
-    '@type': string;
-    from_address?: string;
-    to_address?: string;
-    delegator_address?: string;
-    validator_address?: string;
-    amount: Coin | Coin[];
+export interface Message {
+  '@type': string;
+  from_address?: string;
+  to_address?: string;
+  delegator_address?: string;
+  validator_address?: string;
+  amount: Coin | Coin[];
 }
 export interface Tx {
-    "@type"?: string,
-    "body": {
-        "messages": Message[],
-        "memo": string,
-        "timeout_height": string,
-        "extension_options": any[],
-        "non_critical_extension_options": any[]
-    },
-    "auth_info": {
-        "signer_infos": [
-            {
-                "public_key": Key,
-                "mode_info": {
-                    "single"?: {
-                        "mode": string // "SIGN_MODE_DIRECT"
-                    }
-                },
-                "sequence": string
-            }
-        ],
-        "fee": {
-            "amount": Coin[],
-            "gas_limit": string,
-            "payer": string,
-            "granter": string
-        }
-    },
-    "signatures": string[]
+  '@type'?: string;
+  body: {
+    messages: Message[];
+    memo: string;
+    timeout_height: string;
+    extension_options: any[];
+    non_critical_extension_options: any[];
+  };
+  auth_info: {
+    signer_infos: [
+      {
+        public_key: Key;
+        mode_info: {
+          single?: {
+            mode: string; // "SIGN_MODE_DIRECT"
+          };
+        };
+        sequence: string;
+      }
+    ];
+    fee: {
+      amount: Coin[];
+      gas_limit: string;
+      payer: string;
+      granter: string;
+    };
+  };
+  signatures: string[];
 }
 
 export interface Attributes {
-    index?: boolean,
-    key: string,
-    value: string
+  index?: boolean;
+  key: string;
+  value: string;
 }
 
 export interface TxResponse {
-    "height": string,
-    "txhash": string,
-    "codespace": string,
-    "code": number,
-    "data": string,
-    "raw_log": string,
-    "logs": [
-        {
-            "msg_index": number,
-            "log": string,
-            "events": Attributes[]
-        }
-    ],
-    "info": "",
-    "gas_wanted": "204431",
-    "gas_used": "202682",
-    "tx": Tx,
-    "timestamp": "2022-08-13T23:24:54Z",
-    "events": {
-            "type": string,
-            "attributes": Attributes[]
-        }[]
+  height: string;
+  txhash: string;
+  codespace: string;
+  code: number;
+  data: string;
+  raw_log: string;
+  logs: [
+    {
+      msg_index: number;
+      log: string;
+      events: Attributes[];
+    }
+  ];
+  info: '';
+  gas_wanted: string;
+  gas_used: string;
+  tx: Tx;
+  timestamp: string;
+  events: {
+    type: string;
+    attributes: Attributes[];
+  }[];
 }
 
 export interface PaginatedTxs extends PaginatedResponse {
-    txs: Tx[]
-    tx_responses: TxResponse[]
-    total: number;
+  txs: Tx[];
+  tx_responses: TxResponse[];
+  total: number;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz#d2a39395c587e092d77cbbc80acf956a54f38bf7"
   integrity sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==
 
+"@adraffy/ens-normalize@1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz#63430d04bd8c5e74f8d7d049338f1cd9d4f02069"
+  integrity sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==
+
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
@@ -2283,6 +2288,11 @@
   dependencies:
     undici-types "~5.26.4"
 
+"@types/node@18.15.13":
+  version "18.15.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.13.tgz#f64277c341150c979e42b00e4ac289290c9df469"
+  integrity sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==
+
 "@types/node@^18.11.12":
   version "18.19.30"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.30.tgz#0b1e6f824ed7ce37ef6e56f8f0d7d0ec2847b327"
@@ -2605,6 +2615,11 @@ acorn@^8.10.0, acorn@^8.11.2, acorn@^8.11.3, acorn@^8.8.2:
   version "8.11.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
+
+aes-js@4.0.0-beta.5:
+  version "4.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-4.0.0-beta.5.tgz#8d2452c52adedebc3a3e28465d858c11ca315873"
+  integrity sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==
 
 ansi-escapes@^2.0.0:
   version "2.0.0"
@@ -3871,6 +3886,19 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+ethers@^6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.13.0.tgz#f342958d0f622cf06559f59fbccdc1d30fa64f50"
+  integrity sha512-+yyQQQWEntY5UVbCv++guA14RRVFm1rSnO1GoLFdrK7/XRWMoktNgyG9UjwxrQqGBfGyFKknNZ81YpUS2emCgg==
+  dependencies:
+    "@adraffy/ens-normalize" "1.10.1"
+    "@noble/curves" "1.2.0"
+    "@noble/hashes" "1.3.2"
+    "@types/node" "18.15.13"
+    aes-js "4.0.0-beta.5"
+    tslib "2.4.0"
+    ws "8.5.0"
 
 event-emitter@^0.3.5:
   version "0.3.5"
@@ -6303,8 +6331,7 @@ stop-iteration-iterator@^1.0.0:
   dependencies:
     internal-slot "^1.0.4"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6320,6 +6347,15 @@ string-width@^2.0.0, string-width@^2.1.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -6375,8 +6411,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6403,6 +6438,13 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -6687,6 +6729,11 @@ ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+
+tslib@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@^1.9.0:
   version "1.14.1"
@@ -7231,6 +7278,11 @@ ws@8.13.0:
   version "8.13.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
   integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
+
+ws@8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
+  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
 
 ws@^7:
   version "7.5.9"


### PR DESCRIPTION
I have added the Ethers function for getting the transactions from the EVM directly. This is because, in the current explorer, the shown transactions are wrapped and could be more difficult to understand for the user. In future versions, this will be replaced for backend consumption. 

![image](https://github.com/KiiChain/kii-explorer/assets/85534471/5c18109b-11e6-4560-ab33-9a47bea84d7f)
