### PR TITLE
Add kii backend consumption

### DIFF
--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -1,7 +1,4 @@
-import {
-  type RequestRegistry,
-  adapter,
-} from './registry';
+import { type RequestRegistry, adapter } from './registry';
 
 export const DEFAULT: RequestRegistry = {
   auth_params: { url: '/cosmos/auth/v1beta1/params', adapter },
@@ -192,6 +189,16 @@ export const DEFAULT: RequestRegistry = {
   },
   ibc_core_connection_connections_connection_id_client_state: {
     url: '/ibc/core/connection/v1/connections/{connection_id}/client_state',
+    adapter,
+  },
+
+  // kii backend
+  kii_backend_transactions: {
+    url: 'http://3.134.233.152:3000/transactions',
+    adapter,
+  },
+  kii_backend_blocks: {
+    url: 'http://3.134.233.152:3000/blocks',
     adapter,
   },
 };

--- a/src/libs/registry.ts
+++ b/src/libs/registry.ts
@@ -1,10 +1,12 @@
 import type {
   AuthAccount,
   Block,
+  BlocksEvmResponse,
   ClientStateWithProof,
   Coin,
   ConnectionWithProof,
   DenomTrace,
+  EvmTransactionResponse,
   NodeInfo,
   PaginabledAccounts,
   PaginatedIBCChannels,
@@ -43,7 +45,7 @@ import type {
   Validator,
 } from '@/types/staking';
 import type { PaginatedTxs, Tx, TxResponse } from '@/types';
-import semver from 'semver'
+import semver from 'semver';
 export interface Request<T> {
   url: string;
   adapter: (source: any) => T;
@@ -77,10 +79,10 @@ export interface RequestRegistry extends AbstractRegistry {
   distribution_community_pool: Request<{ pool: Coin[] }>;
   distribution_delegator_rewards: Request<{
     rewards: {
-      validator_address: string, 
-      reward: Coin[]
-    }[],
-    total: Coin[]
+      validator_address: string;
+      reward: Coin[];
+    }[];
+    total: Coin[];
   }>;
 
   mint_inflation: Request<{ inflation: string }>;
@@ -92,7 +94,7 @@ export interface RequestRegistry extends AbstractRegistry {
   }>;
   mint_annual_provisions: Request<{ annual_provisions: string }>;
 
-  slashing_params: Request<{params: SlashingParam}>;
+  slashing_params: Request<{ params: SlashingParam }>;
   slashing_signing_info: Request<PaginatedSigningInfo>;
 
   gov_params_voting: Request<GovParams>;
@@ -151,6 +153,9 @@ export interface RequestRegistry extends AbstractRegistry {
   ibc_core_connection_connections: Request<PaginatedIBCConnections>;
   ibc_core_connection_connections_connection_id: Request<ConnectionWithProof>;
   ibc_core_connection_connections_connection_id_client_state: Request<ClientStateWithProof>;
+
+  kii_backend_transactions: Request<EvmTransactionResponse>;
+  kii_backend_blocks: Request<BlocksEvmResponse>;
 }
 
 export function adapter<T>(source: any): T {
@@ -173,16 +178,20 @@ export const VERSION_REGISTRY: ApiProfileRegistry = {};
 // ChainName Profile Registory
 export const NAME_REGISTRY: ApiProfileRegistry = {};
 
-export function registryVersionProfile(version: string, requests: RequestRegistry) {
-  VERSION_REGISTRY[version] = requests
+export function registryVersionProfile(
+  version: string,
+  requests: RequestRegistry
+) {
+  VERSION_REGISTRY[version] = requests;
 }
 
-export function registryChainProfile(version: string, requests: RequestRegistry) {
-  NAME_REGISTRY[version] = requests
+export function registryChainProfile(
+  version: string,
+  requests: RequestRegistry
+) {
+  NAME_REGISTRY[version] = requests;
 }
-export function findApiProfileByChain(
-  name: string,
-): RequestRegistry {
+export function findApiProfileByChain(name: string): RequestRegistry {
   const url = NAME_REGISTRY[name];
   // if (!url) {
   //   throw new Error(`Unsupported version or name: ${name}`);
@@ -191,12 +200,12 @@ export function findApiProfileByChain(
 }
 
 export function findApiProfileBySDKVersion(
-  version: string,
+  version: string
 ): RequestRegistry | undefined {
   let closestVersion: string | null = null;
 
   for (const k in VERSION_REGISTRY) {
-    const key = k.replace('v', "")
+    const key = k.replace('v', '');
     // console.log(semver.gt(key, version), semver.gte(version, key), key, version)
     if (semver.lte(key, version)) {
       if (!closestVersion || semver.gt(key, closestVersion)) {

--- a/src/modules/[chain]/index.vue
+++ b/src/modules/[chain]/index.vue
@@ -16,7 +16,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { Icon } from '@iconify/vue';
 import { computed, onMounted, ref } from 'vue';
 import router from '@/router';
-import type { Coin, Tx, TxResponse } from '@/types';
+import type { Block, Coin, Tx, TxResponse } from '@/types';
 import { shortenAddress } from '@/libs/utils';
 import { defineChain, createPublicClient, http, decodeFunctionData, parseUnits } from 'viem'
 import bankAbi from '@/assets/abi/bank.json'
@@ -40,6 +40,7 @@ let searchQuery = ref('');
 let latestTransactions = ref<TxResponse[]>([]);
 let transactionsCount = ref(0);
 let gasPriceEvm = ref('');
+let latestBlocks = ref<Block[]>([]);
 
 const isKiichain = selectedChain === 'kiichain'
 
@@ -53,9 +54,10 @@ onMounted(async () => {
     if(isKiichain){
       const gasPrice = await publicClient.getGasPrice() 
       gasPriceEvm.value = gasPrice.toString()
+      latestBlocks.value =(await baseStore.fetchLatestEvmBlocks()).slice(0,20)
       const transactions = await bankStore.fetchLatestTxsEvm(blockStore.current?.assets[0].base ?? '');
       latestTransactions.value = transactions.slice(0, 20);
-      transactionsCount.value = transactions.length
+      transactionsCount.value = transactions.length  
       return
     }
     const txCount = await blockStore.rpc.getTxsCount();
@@ -66,10 +68,6 @@ onMounted(async () => {
     console.log(err)
   }
 
-});
-
-const latestBlocks = computed(() => {
-  return baseStore.recents.reverse().slice(0, 20);
 });
 
 const getAmountEVM = (transaction : TxResponse): Coin=>{
@@ -288,7 +286,7 @@ function confirm() {
           </tr>
         </thead>
         <tr
-          v-for="item in latestBlocks"
+          v-for="item in latestBlocks!"
           class="border-y-solid border-y-1 border-[#EAECF0]"
         >
           <td class="py-4">

--- a/src/stores/useBaseStore.ts
+++ b/src/stores/useBaseStore.ts
@@ -7,112 +7,116 @@ import { hashTx } from '@/libs';
 import { fromBase64 } from '@cosmjs/encoding';
 
 export const useBaseStore = defineStore('baseStore', {
-    state: () => {
-        return {
-            earlest: {} as Block,
-            latest: {} as Block,
-            recents: [] as Block[],
-            theme: (window.localStorage.getItem('theme') || 'dark') as
-                | 'light'
-                | 'dark',
-        };
+  state: () => {
+    return {
+      earlest: {} as Block,
+      latest: {} as Block,
+      recents: [] as Block[],
+      theme: (window.localStorage.getItem('theme') || 'dark') as
+        | 'light'
+        | 'dark',
+    };
+  },
+  getters: {
+    blocktime(): number {
+      if (this.earlest && this.latest) {
+        if (
+          this.latest.block?.header?.height !==
+          this.earlest.block?.header?.height
+        ) {
+          const diff = dayjs(this.latest.block?.header?.time).diff(
+            this.earlest.block?.header?.time
+          );
+          const blocks =
+            Number(this.latest.block.header.height) -
+            Number(this.earlest.block.header.height);
+          return diff / blocks;
+        }
+      }
+      return 6000;
     },
-    getters: {
-        blocktime(): number {
-            if (this.earlest && this.latest) {
-                if (
-                    this.latest.block?.header?.height !==
-                    this.earlest.block?.header?.height
-                ) {
-                    const diff = dayjs(this.latest.block?.header?.time).diff(
-                        this.earlest.block?.header?.time
-                    );
-                    const blocks = Number(this.latest.block.header.height) - Number(this.earlest.block.header.height)
-                    return diff / (blocks);
-                }
-            }
-            return 6000;
-        },
-        blockchain() {
-            return useBlockchain();
-        },
-        currentChainId(): string {
-            return this.latest.block?.header.chain_id || '';
-        },
-        txsInRecents() {
-            const txs = [] as {
-                height: string;
-                hash: string;
-                tx: DecodedTxRaw;
-            }[];
-            this.recents.forEach((b) =>
-                b.block?.data?.txs.forEach((tx: string) => {
-                    if (tx) {
-                        const raw = fromBase64(tx);
-                        try {
-                            txs.push({
-                                height: b.block.header.height,
-                                hash: hashTx(raw),
-                                tx: decodeTxRaw(raw),
-                            });
-                        } catch (e) {
-                            console.error(e);
-                        }
-                    }
-                })
-            );
-            return txs.sort((a, b) => {return Number(b.height) - Number(a.height)});
-        },
+    blockchain() {
+      return useBlockchain();
     },
-    actions: {
-        async initial() {
-            this.fetchLatest();
-        },
-        async clearRecentBlocks() {
-            this.recents = [];
-        },
-        async fetchLatest() {
-            this.latest = await this.blockchain.rpc?.getBaseBlockLatest();
-            if (
-                !this.earlest ||
-                this.earlest?.block?.header?.chain_id !=
-                    this.latest?.block?.header?.chain_id
-            ) {
-                //reset earlest and recents
-                this.earlest = this.latest;
-                this.recents = [];
+    currentChainId(): string {
+      return this.latest.block?.header.chain_id || '';
+    },
+    txsInRecents() {
+      const txs = [] as {
+        height: string;
+        hash: string;
+        tx: DecodedTxRaw;
+      }[];
+      this.recents.forEach((b) =>
+        b.block?.data?.txs.forEach((tx: string) => {
+          if (tx) {
+            const raw = fromBase64(tx);
+            try {
+              txs.push({
+                height: b.block.header.height,
+                hash: hashTx(raw),
+                tx: decodeTxRaw(raw),
+              });
+            } catch (e) {
+              console.error(e);
             }
-            //check if the block exists in recents
-            if (
-                this.recents.findIndex(
-                    (x) => x?.block_id?.hash === this.latest?.block_id?.hash
-                ) === -1
-            ) {
-                if (this.recents.length >= 50) {
-                    this.recents.shift();
-                }
-                this.recents.push(this.latest);
-            }
-            return this.latest;
-        },
+          }
+        })
+      );
+      return txs.sort((a, b) => {
+        return Number(b.height) - Number(a.height);
+      });
+    },
+  },
+  actions: {
+    async initial() {
+      this.fetchLatest();
+    },
+    async clearRecentBlocks() {
+      this.recents = [];
+    },
+    async fetchLatest() {
+      this.latest = await this.blockchain.rpc?.getBaseBlockLatest();
+      if (
+        !this.earlest ||
+        this.earlest?.block?.header?.chain_id !=
+          this.latest?.block?.header?.chain_id
+      ) {
+        //reset earlest and recents
+        this.earlest = this.latest;
+        this.recents = [];
+      }
+      //check if the block exists in recents
+      if (
+        this.recents.findIndex(
+          (x) => x?.block_id?.hash === this.latest?.block_id?.hash
+        ) === -1
+      ) {
+        if (this.recents.length >= 50) {
+          this.recents.shift();
+        }
+        this.recents.push(this.latest);
+      }
+      return this.latest;
+    },
 
-        async fetchValidatorByHeight(height?: number, offset = 0) {
-            return this.blockchain.rpc.getBaseValidatorsetAt(
-                String(height),
-                offset
-            );
-        },
-        async fetchLatestValidators(offset = 0) {
-            return this.blockchain.rpc.getBaseValidatorsetLatest(offset);
-        },
-        async fetchBlock(height?: number | string) {
-            return this.blockchain.rpc.getBaseBlockAt(String(height));
-        },
-        async fetchAbciInfo() {
-            return this.blockchain.rpc.getBaseNodeInfo();
-        },
-        // async fetchNodeInfo() {
-        //     return this.blockchain.rpc.no()
-        // }
+    async fetchValidatorByHeight(height?: number, offset = 0) {
+      return this.blockchain.rpc.getBaseValidatorsetAt(String(height), offset);
     },
+    async fetchLatestValidators(offset = 0) {
+      return this.blockchain.rpc.getBaseValidatorsetLatest(offset);
+    },
+    async fetchBlock(height?: number | string) {
+      return this.blockchain.rpc.getBaseBlockAt(String(height));
+    },
+    async fetchAbciInfo() {
+      return this.blockchain.rpc.getBaseNodeInfo();
+    },
+    // async fetchNodeInfo() {
+    //     return this.blockchain.rpc.no()
+    // }
+    async fetchLatestEvmBlocks(): Promise<Block[]> {
+      return await this.blockchain.rpc.getBaseLatestBlocksEvm();
+    },
+  },
 });

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -1,103 +1,128 @@
-import type { Key } from "./common"
+import type { Key } from './common';
+import type { Receipt } from './transaction';
 
 export interface NodeInfo {
-    default_node_info: {
-        protocol_version: {
-            p2p: string,
-            block: string,
-            app: string
-        },
-        default_node_id: string,
-        listen_addr: string,
-        network: string,
-        version: string,
-        channels: string,
-        moniker: string,
-        other: {
-            tx_index: string,
-            rpc_address: string
-        }
-    },
-    application_version: {
-        name: string,
-        app_name: string,
-        version: string,
-        git_commit: string,
-        build_tags: string,
-        go_version: string,
-        build_deps: [
-            {
-                path: string,
-                version: string,
-                sum: string,
-            },
-        ],
-        cosmos_sdk_version: string,
-    }
+  default_node_info: {
+    protocol_version: {
+      p2p: string;
+      block: string;
+      app: string;
+    };
+    default_node_id: string;
+    listen_addr: string;
+    network: string;
+    version: string;
+    channels: string;
+    moniker: string;
+    other: {
+      tx_index: string;
+      rpc_address: string;
+    };
+  };
+  application_version: {
+    name: string;
+    app_name: string;
+    version: string;
+    git_commit: string;
+    build_tags: string;
+    go_version: string;
+    build_deps: [
+      {
+        path: string;
+        version: string;
+        sum: string;
+      }
+    ];
+    cosmos_sdk_version: string;
+  };
 }
 export interface BlockId {
-    hash: string,
-    part_set_header: {
-        total: number,
-        hash: string
-    }
+  hash: string;
+  part_set_header: {
+    total: number;
+    hash: string;
+  };
 }
 
-export interface Signature 
-{
-    block_id_flag: string,
-    validator_address: string,
-    timestamp: string,
-    signature: string,
+export interface Signature {
+  block_id_flag: string;
+  validator_address: string;
+  timestamp: string;
+  signature: string;
 }
 
 export interface Block {
-    block_id: BlockId,
-    block: {
-        header: {
-            version: {
-                block: string,
-                app: string
-            },
-            chain_id: string,
-            height: string,
-            time: string,
-            last_block_id: BlockId,
-            last_commit_hash: string,
-            data_hash: string,
-            validators_hash: string,
-            next_validators_hash: string,
-            consensus_hash: string,
-            app_hash: string,
-            last_results_hash: string,
-            evidence_hash: string,
-            proposer_address: string,
-        },
-        data: {
-            txs: any[]
-        },
-        evidence: {
-            evidence: any[]
-        },
-        last_commit: Commit
-    }
+  block_id: BlockId;
+  block: {
+    header: {
+      version: {
+        block: string;
+        app: string;
+      };
+      chain_id: string;
+      height: string;
+      time: string;
+      last_block_id: BlockId;
+      last_commit_hash: string;
+      data_hash: string;
+      validators_hash: string;
+      next_validators_hash: string;
+      consensus_hash: string;
+      app_hash: string;
+      last_results_hash: string;
+      evidence_hash: string;
+      proposer_address: string;
+    };
+    data: {
+      txs: any[];
+    };
+    evidence: {
+      evidence: any[];
+    };
+    last_commit: Commit;
+  };
 }
 
 export interface Commit {
-    height: string,
-    round: number,
-    block_id: BlockId,
-    signatures: Signature[]
+  height: string;
+  round: number;
+  block_id: BlockId;
+  signatures: Signature[];
 }
 
 export interface TendermintValidator {
-    address: string,
-    pub_key: Key,
-    voting_power: string,
-    proposer_priority: string
+  address: string;
+  pub_key: Key;
+  voting_power: string;
+  proposer_priority: string;
 }
 
 export interface PaginatedTendermintValidator {
-    validators: TendermintValidator[],
-    block_height: string
+  validators: TendermintValidator[];
+  block_height: string;
+}
+
+export interface BlocksEvmResponse {
+  success: boolean;
+  errorMessage: string;
+  blocks: Blocks;
+  quantity: number;
+}
+
+export interface Blocks {
+  blocks: EvmBlock[];
+  pagination: Pagination;
+}
+
+export interface EvmBlock {
+  transactions: Receipt[];
+  withdrawals: any[];
+  time: number;
+  blockNumber: number;
+  gasUsed: number;
+}
+
+interface Pagination {
+  page: number;
+  totalPages: number;
 }

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -75,3 +75,36 @@ export interface PaginatedTxs extends PaginatedResponse {
   tx_responses: TxResponse[];
   total: number;
 }
+
+export interface EvmTransactionResponse {
+  success: boolean;
+  errorMessage: string;
+  transactions: Transaction[];
+  quantity: number;
+}
+
+export interface Transaction {
+  transaction: Receipt;
+  sender: string;
+  success: boolean;
+  timestamp: string;
+}
+
+export interface Receipt {
+  type: string;
+  chainId: string;
+  nonce: string;
+  to: string;
+  gas: string;
+  gasPrice?: string;
+  maxPriorityFeePerGas?: string;
+  maxFeePerGas?: string;
+  value: string;
+  input: string;
+  accessList?: any[];
+  v: string;
+  r: string;
+  s: string;
+  yParity?: string;
+  hash: string;
+}


### PR DESCRIPTION
This commit has the changes for showing the blocks and transactions on the main page. To get the data, the explorer uses the new backend service made for Kii
![image](https://github.com/KiiChain/kii-explorer/assets/85534471/4e2cad3a-eed9-4759-812d-9eee352c8ee1)
