### PR TITLE
:sparkles: List recent transactions and blocks in Block navbar

### DIFF
--- a/src/libs/client.ts
+++ b/src/libs/client.ts
@@ -270,7 +270,7 @@ export class CosmosRestClient extends BaseRestClient<RequestRegistry> {
     const sortedBlocks = blocksResponse.blocks.blocks.sort(
       (a, b) => b.blockNumber - a.blockNumber
     );
-    const latestBlocksPromise = sortedBlocks.slice(0, 20).map(async (block) => {
+    const latestBlocksPromise = sortedBlocks.slice(0, 30).map(async (block) => {
       return await this.getBaseBlockAt(block.blockNumber);
     });
     const latestBlocks = await Promise.all(latestBlocksPromise);

--- a/src/libs/ethers.ts
+++ b/src/libs/ethers.ts
@@ -1,6 +1,6 @@
 import type { Coin, Transaction, TxResponse } from '@/types';
 import kiichain from '../../chains/testnet/kiichain.json';
-import type { ethers, TransactionResponse } from 'ethers';
+import { ethers, TransactionResponse } from 'ethers';
 
 const getTransactionEVM = async (
   transactionHash: string,
@@ -19,13 +19,13 @@ export const convertTransaction = (transaction: Transaction): TxResponse => {
   const { assets } = kiichain;
   const assetSymbol = assets[0].symbol;
   const amount: Coin = {
-    amount: (parseInt(receipt.value, 16) / 1e18).toString(), // Convert tkii to Kii
+    amount: ethers.formatEther(BigInt(receipt.value)), // Convert tkii to Kii
     denom: assetSymbol,
   };
 
   const fee: Coin[] = [
     {
-      amount: '',
+      amount: ethers.formatEther(BigInt(receipt.gas)), // Convert tkii to Kii,
       denom: assetSymbol,
     },
   ];


### PR DESCRIPTION
I list the most 30 recent blocks. Also, those blocks update automatically
 
![image](https://github.com/user-attachments/assets/e92c2bed-d5f5-4542-ac89-952441e72372)

The same for the latest transactions 

![image](https://github.com/user-attachments/assets/a63f6196-be9f-418a-a745-d5dad4f3966b)

Finally, I commented the Future section 

![image](https://github.com/user-attachments/assets/dfb3aedb-f426-4ce1-8cfb-aab508f0de87)
